### PR TITLE
fix: product get response permission removed

### DIFF
--- a/src/routes/product.route.ts
+++ b/src/routes/product.route.ts
@@ -41,14 +41,12 @@ router.post(
 
 router.get(
     "/",
-    [checkAccessToken, hasPermission([Role.ADMIN])],
     (req: Request, res: Response, next: NextFunction) =>
         productController.getAll(req, res, next) as unknown as RequestHandler,
 );
 
 router.get(
     "/:productId",
-    [checkAccessToken, hasPermission([Role.ADMIN])],
     (req: Request, res: Response, next: NextFunction) =>
         productController.get(req, res, next) as unknown as RequestHandler,
 );


### PR DESCRIPTION
## Description
*  Removed any authenticate user permission for get `/api/product` and `/api/product/:productId` because we need to show product and product list without any authenticate user client.

## Changes
* Remove checkAccess and hasPermission middleware from `/api/product` and `/api/product/:productId` api endpoints.

## Checklist
* [x] Code has been tested locally.
* [x] All existing tests pass.

## Use
```shell
[GET] /api/product
[GET] /api/product/{productId}
``` 